### PR TITLE
Tiles animated using CSS3 transitions instead of using jQuery.animate()

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -58,8 +58,20 @@ p[data-action="lose"] {
     box-shadow: 2px 1px 12px #aaa;
 }
 
-.red, .blue, .yellow, .green {
+.tile {
 	opacity: 0.6;
+	-webkit-transition: opacity 250ms ease;
+	-moz-transition: opacity 250ms ease;
+	-ms-transition: opacity 250ms ease;
+	-o-transition: opacity 250ms ease;
+	transition: opacity 250ms ease;
+}
+
+.tile.lit {
+	opacity: 1;
+}
+
+.red, .blue, .yellow, .green {
 	height: 290px;
 	-webkit-border-radius: 150px 150px 150px 150px;
 	border-radius: 150px 150px 150px 150px;

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
 			<div class="game-board">
 				<div class="simon">
 					<ul>
-						<li class="red" data-tile="1"></li>
-						<li class="blue" data-tile="2"></li>
-						<li class="yellow" data-tile="3"></li>
-						<li class="green" data-tile="4"></li>
+						<li class="tile red" data-tile="1"></li>
+						<li class="tile blue" data-tile="2"></li>
+						<li class="tile yellow" data-tile="3"></li>
+						<li class="tile green" data-tile="4"></li>
 					</ul>
 				</div>
 			</div>

--- a/js/app/simon.js
+++ b/js/app/simon.js
@@ -122,14 +122,12 @@ define(['jquery'], function($) {
 
 		lightUp: function(tile) {
 			if (this.mode !== 'sound-only') {
-				$('[data-tile=' + tile + ']').animate({
-					opacity: 1
-				}, 250, function() {
-					setTimeout(function() {
-						$('[data-tile=' + tile + ']').css('opacity', 0.6);
-					}, 250);
-				});
+				var $tile = $('[data-tile=' + tile + ']').addClass('lit');
+				window.setTimeout(function() {
+					$tile.removeClass('lit');
+				}, 300);
 			}
+
 		},
 
 		// we are embedding the sound file on the fly for the following benefits:


### PR DESCRIPTION
Handling the animation properties in CSS helps to separate styling concerns away from the logic of the app.
